### PR TITLE
Adjusted ramMin for cwls, like commit 4794db9

### DIFF
--- a/setup/cwl/tools/cmo-bwa-mem/0.7.5a/cmo-bwa-mem.cwl
+++ b/setup/cwl/tools/cmo-bwa-mem/0.7.5a/cmo-bwa-mem.cwl
@@ -51,7 +51,7 @@ arguments:
 requirements:
   InlineJavascriptRequirement: {}
   ResourceRequirement:
-    ramMin: 16000
+    ramMin: 24000
     coresMin: 4
 
 doc: |

--- a/setup/cwl/tools/cmo-picard.AddOrReplaceReadGroups/2.9/cmo-picard.AddOrReplaceReadGroups.cwl
+++ b/setup/cwl/tools/cmo-picard.AddOrReplaceReadGroups/2.9/cmo-picard.AddOrReplaceReadGroups.cwl
@@ -55,7 +55,7 @@ arguments:
 requirements:
   InlineJavascriptRequirement: {}
   ResourceRequirement:
-    ramMin: 8000
+    ramMin: 16000
     coresMin: 1
 
 doc: |

--- a/vm/install-singularity.sh
+++ b/vm/install-singularity.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-SINGULARITY_VERSION="v3.0.3"
+SINGULARITY_VERSION="v3.1.1"
 SINGULARITY_INSTALL_TEMP_DIR="/tmp/singularity"
 
 # Install system dependencies


### PR DESCRIPTION
Carries over commit https://github.com/mskcc/roslin-variant/commit/425970cb18efb69b42edf26f92c07b7683a62576 from `2.4.x`